### PR TITLE
Allow unicode email

### DIFF
--- a/blazeweb/mail.py
+++ b/blazeweb/mail.py
@@ -204,7 +204,7 @@ class SMTPConnection(object):
                 self.connection.sendmail(
                     email_message.from_email,
                     recipients,
-                    email_message.message().as_string())
+                    email_message.message().as_bytes())
             else:
                 log.warn('email.is_live = False, email getting skipped')
             log_recipients = ';'.join(recipients)


### PR DESCRIPTION
- sendmail converts strings to ascii
- we should provide the bytes instead

https://docs.python.org/3/library/smtplib.html?highlight=sendmail#smtplib.SMTP.sendmail